### PR TITLE
Require Pageflow 12

### DIFF
--- a/pageflow-text-page.gemspec
+++ b/pageflow-text-page.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.12.pre'
+  spec.add_runtime_dependency 'pageflow', '~> 12.0.pre'
 
   # Using translations from rails locales in javascript code.
   spec.add_runtime_dependency 'i18n-js'


### PR DESCRIPTION
`0.12` will be released as `12.0`.