### PR TITLE
include styles for right aligned text

### DIFF
--- a/app/assets/stylesheets/pageflow/text_page.css.scss
+++ b/app/assets/stylesheets/pageflow/text_page.css.scss
@@ -278,13 +278,12 @@ $inverted-background-color: black;
 }
 
 .text_position_right.page .text_page {
-    h2 .title,
-    h2 .subtitle,
-    h2 .tagline
-     {
-      max-width: 500px;
-    }
+  h2 .title,
+  h2 .subtitle,
+  h2 .tagline {
+    max-width: 500px;
   }
+}
 
 .text_position_center, .text_position_right .text_position_center {
   .text_page {

--- a/app/assets/stylesheets/pageflow/text_page.css.scss
+++ b/app/assets/stylesheets/pageflow/text_page.css.scss
@@ -277,6 +277,15 @@ $inverted-background-color: black;
   }
 }
 
+.text_position_right.page .text_page {
+    h2 .title,
+    h2 .subtitle,
+    h2 .tagline
+     {
+      max-width: 500px;
+    }
+  }
+
 .text_position_center, .text_position_right .text_position_center {
   .text_page {
     .shadow {


### PR DESCRIPTION
In codevise/pageflow#780, title max width has been made configurable to support themes with larger fonts. While for other page types it makes sense to display titles further on the left when text position right is active, for the text page, this makes the result almost identical to centered text. Hard code the previous max width to override theme configuration for this page type.