### PR TITLE
Prevent text from overlapping content image

### DIFF
--- a/app/assets/stylesheets/pageflow/text_page.css.scss
+++ b/app/assets/stylesheets/pageflow/text_page.css.scss
@@ -355,6 +355,7 @@ $inverted-background-color: black;
 
         h3, p {
           margin: 0;
+          max-width: 500px;
         }
 
         @include narrow_desktop {


### PR DESCRIPTION
When themes allowed an increased page content max width, the text
could overlap the image if it was positioned in center and sticky
image was enabled.

Before the theme changes, the `max-width: 500px` rule applied
for the content text of all pages.