### PR TITLE
Prevent overlapping fonts on text-page headers with orientation center  

### DIFF
--- a/app/assets/stylesheets/pageflow/text_page.scss
+++ b/app/assets/stylesheets/pageflow/text_page.scss
@@ -90,7 +90,12 @@ $inverted-background-color: black;
             padding: 2em 0;
             margin: 0;
             span {
-              margin: 0 auto;
+              margin-right: auto;
+              margin-left: auto;
+            }
+
+            .subtitle {
+              margin-bottom: 0em;
             }
 
             padding-right: $nav-bar-margin;


### PR DESCRIPTION
Now when center is chosen as an option for the text-page header fonts no longer overlap. 
Therefore auto margin was removed and replaced with margin only for left and right. 
To prevent unnecessary spacing the margin-bottom from the .subtitle was also removed.