### PR TITLE
Make background color of content area configurable

### DIFF
--- a/app/assets/javascript/pageflow/text_page/editor.js
+++ b/app/assets/javascript/pageflow/text_page/editor.js
@@ -23,6 +23,14 @@ pageflow.ConfigurationEditorView.register('text_page', {
       this.input('text_title', pageflow.TextInputView);
       this.input('text', pageflow.TextAreaInputView);
       this.input('invert_text', pageflow.CheckBoxInputView);
+      this.input('text_page_background_color', pageflow.ColorInputView, {
+        defaultValue: function(invertText) {
+          return invertText ? '#000000' : '#ffffff';
+        },
+        defaultValueBinding: 'invert_text',
+
+        swatches: usedBackgroundColors()
+      });
 
       this.input('text_image_id', pageflow.FileInputView, {
         collection: pageflow.imageFiles,
@@ -49,5 +57,11 @@ pageflow.ConfigurationEditorView.register('text_page', {
       });
       this.group('options');
     });
+
+    function usedBackgroundColors() {
+      return _.chain(pageflow.pages.map(function(page) {
+        return page.configuration.get('text_page_background_color');
+      })).uniq().compact().value();
+    }
   }
 });

--- a/app/assets/javascript/pageflow/text_page/page_type.js
+++ b/app/assets/javascript/pageflow/text_page/page_type.js
@@ -223,6 +223,10 @@ pageflow.react.registerPageTypeWithDefaultBackground('text_page', {
     pageElement.find('.content_and_background').toggleClass('invert_text', !!configuration.get('invert_text'));
     pageElement.data('invertIndicator', !configuration.get('invert_text'));
 
+    pageElement.find('.content_background_layer').css({
+      backgroundColor: configuration.get('text_page_background_color') || ''
+    });
+
     pageElement.find('.shadow, .header_background_layer').css({
       opacity: configuration.get('gradient_opacity') / 100
     });

--- a/app/views/pageflow/text_page/page.html.erb
+++ b/app/views/pageflow/text_page/page.html.erb
@@ -20,7 +20,7 @@
       <div class="contentWrapper">
         <div class="page_spacer"></div>
         <div class="contentInnerWrapper">
-          <div class="content_background_layer"></div>
+          <div class="content_background_layer" style="<%= configuration['text_page_background_color'] ? "background-color: #{configuration['text_page_background_color']}" : '' %>"></div>
           <div class="page_header">
             <div class="header_background_layer" style="opacity: <%= configuration['gradient_opacity'].to_i / 100.0 %>"></div>
             <h2>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,7 +43,6 @@ de:
           header: Titel
       inline_help:
         pageflow/page:
-          invert_text: Vertauscht Text- und Hintergrundfarbe im Fließtextbereich.
           prevent_fullscreen: Verhindert, dass das Fließtextbild bei Klick auf das Bild im Vollbild dargestellt wird.
           sticky_inline_image: Das Bild wird zunächst zusammen mit dem Text gescrollt, bleibt dann aber vertikal zentriert stehen, während der Text weiter scrollt.
           text: Dies ist der Bereich für den Fließtext dieser Seite. Dieser Seitentyp ist für lange Texte optimiert. Bei Kurztexten sollte auf andere Seitentypen zurückgegriffen werden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,6 @@ en:
           header: Title area
       inline_help:
         pageflow/page:
-          invert_text: Switches text and background colors
           prevent_fullscreen: Prevents the image from opening fullscreen on click
           sticky_inline_image: The image scrolls with the text but eventually remains at a vertically centered position.
           text: This is the main contents of the page. This page type is made for long texts. Use a different page type if your main content text is short.

--- a/config/locales/new/background_color.de.yml
+++ b/config/locales/new/background_color.de.yml
@@ -1,0 +1,11 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/page:
+        text_page_background_color: "Hintergrundfarbe"
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/page:
+          text_page_background_color: "Nutze die 'Farben des Textbereichs invertieren' Option, um einen ausreichenden Kontrast des Texts zur gewählten Hintergrundfarbe sicherzustellen."
+          invert_text: "Weißen Text auf dunklem Grund anzeigen."

--- a/config/locales/new/background_color.en.yml
+++ b/config/locales/new/background_color.en.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/page:
+        text_page_background_color: "Background color"
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/page:
+          text_page_background_color: "Use the 'invert text area color' option to make sure there is sufficient contrast between text and selected background color."
+          invert_text: "Display white text on dark background."

--- a/lib/pageflow/text_page/engine.rb
+++ b/lib/pageflow/text_page/engine.rb
@@ -6,8 +6,7 @@ module Pageflow
       isolate_namespace Pageflow::TextPage
 
       config.autoload_paths << File.join(config.root, 'lib')
+      config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
     end
   end
 end
-
-

--- a/pageflow-text-page.gemspec
+++ b/pageflow-text-page.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', '~> 12.x'
+  spec.add_runtime_dependency 'pageflow', '~> 12.2.x'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'


### PR DESCRIPTION
Display default colors by default based on `invert_text` option.