### PR TITLE
Restrict swissinfo-theme-induced text max-width to left text layout

### DIFF
--- a/app/assets/stylesheets/pageflow/text_page/themes/default.scss
+++ b/app/assets/stylesheets/pageflow/text_page/themes/default.scss
@@ -29,13 +29,17 @@ $text-page-anchor-inverted-color: $page-anchor-color !default;
 @include pageflow-page-type-pictograms("text_page");
 
 .page .text_page {
+  .inline_text_position_left {
+    .page_text {
+      @include wide_desktop {
+        max-width: $text-page-page-text-wide-desktop-max-width;
+      }
+    }
+  }
+
   .page_text {
     font-size: $text-page-content-text-base-font-size;
     max-width: 500px;
-
-    @include wide_desktop {
-      max-width: $text-page-page-text-wide-desktop-max-width;
-    }
 
     @include phone {
       font-size: $text-page-content-text-phone-base-font-size;


### PR DESCRIPTION
Customer Swissinfo was very scrupulous concerning pixel-perfect layout in their theme.
One of their requirements broke the layout for right-positioned text pages.
This restricts the max-width setting in their theme to left-positioned text.

REDMINE-16909
REDMINE-17182